### PR TITLE
log profile to only add missing types

### DIFF
--- a/add_cdl_eal_to_log_forwarding_profile/.meta-cnc.yaml
+++ b/add_cdl_eal_to_log_forwarding_profile/.meta-cnc.yaml
@@ -35,10 +35,14 @@ snippets:
       capture_value: /config/shared/log-settings/profiles/entry[@name='{{ log_profile_name }}']/@name
     - name: shared_log_profile_entries
       capture_list:  /config/shared/log-settings/profiles/entry[@name='{{ log_profile_name }}']/match-list/entry/@name
+    - name: shared_configured_log_types
+      capture_list:  /config/shared/log-settings/profiles/entry[@name='{{ log_profile_name }}']/match-list//entry/log-type/text()
     - name: vsys_log_profile
       capture_value: /config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/log-settings/profiles/entry[@name='{{ log_profile_name }}']/@name
     - name: vsys_log_profile_entries
       capture_list:  /config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/log-settings/profiles/entry[@name='{{ log_profile_name }}']/match-list/entry/@name
+    - name: vsys_configured_log_types
+      capture_list: /config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/log-settings/profiles/entry[@name='{{ log_profile_name }}']/match-list/entry/log-type/text()
 
 - name: update shared profile with CDL log forwarding
   xpath: /config/shared/log-settings/profiles
@@ -51,12 +55,14 @@ snippets:
         </entry>
       {%- endfor %}
       {%- for item in log_types %}
-        <entry name="{{ item }}-enhanced-app-logging">
-          <send-to-panorama>yes</send-to-panorama>
-          <log-type>{{ item }}</log-type>
-          <filter>All Logs</filter>
-          <quarantine>no</quarantine>
-        </entry>
+        {%- if item not in shared_configured_log_types %}
+          <entry name="{{ item }}-enhanced-app-logging">
+            <send-to-panorama>yes</send-to-panorama>
+            <log-type>{{ item }}</log-type>
+            <filter>All Logs</filter>
+            <quarantine>no</quarantine>
+          </entry>
+        {%- endif %}
       {%- endfor %}
       </match-list>
       <enhanced-application-logging>yes</enhanced-application-logging>
@@ -74,12 +80,14 @@ snippets:
         </entry>
       {%- endfor %}
       {%- for item in log_types %}
-        <entry name="{{ item }}-enhanced-app-logging">
-          <send-to-panorama>yes</send-to-panorama>
-          <log-type>{{ item }}</log-type>
-          <filter>All Logs</filter>
-          <quarantine>no</quarantine>
-        </entry>
+        {%- if item not in vsys_configured_log_types %}
+          <entry name="{{ item }}-enhanced-app-logging">
+            <send-to-panorama>yes</send-to-panorama>
+            <log-type>{{ item }}</log-type>
+            <filter>All Logs</filter>
+            <quarantine>no</quarantine>
+          </entry>
+        {%- endif %}
       {%- endfor %}
       </match-list>
       <enhanced-application-logging>yes</enhanced-application-logging>


### PR DESCRIPTION
## Description

TME feedback that only missing log types should be auto-added for eal requirements. Skillet updated to meet this requirement

## Motivation and Context

Only missing types should be added. Misconception about the EAL updates based on UI observations.

## How Has This Been Tested?

local device testing with panhandler and VM-50

## Types of changes

skillet snippet logic and capture output added

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
